### PR TITLE
updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,51 @@ npm install deck.gl
 pip install pydeck
 ```
 
+### Julia
+
+```bash
+git clone --single-branch --branch pydeck/julia-pycall-binding git@github.com:captchanjack/deck.gl.git
+cd deck.gl/bindings/pydeck
+yarn bootstrap
+pip install . 
+```
+```julia
+using PyCall
+
+pydeck = pyimport("pydeck")
+
+UK_ACCIDENTS_DATA = ("https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv")
+MAPBOX_API_KEY  ="pk.eyJ1IjoiY2FwdGNoYW5qYWNrIiwiYSI6ImNrMzJ1enJoZjBueWwzY245ZDV0YjJ3Z3YifQ.VAWolOVu6eDYSnj3SC4NeQ"
+
+
+layer = pydeck.Layer(
+    "HexagonLayer",
+    UK_ACCIDENTS_DATA,
+    get_position=["lng", "lat"],
+    auto_highlight=true,
+    elevation_scale=50,
+    pickable=true,
+    elevation_range=[0, 3000],
+    extruded=true,                 
+    coverage=1)
+
+# Set the viewport location
+view_state = pydeck.ViewState(
+    longitude=-1.415,
+    latitude=52.2323,
+    zoom=6,
+    min_zoom=5,
+    max_zoom=15,
+    pitch=40.5,
+    bearing=-27.36)
+
+# Combined all of it and render a viewport
+r = pydeck.Deck(layers=[layer], initial_view_state=view_state,
+             mapbox_key=MAPBOX_API_KEY,
+            )
+r.to_html("nodes.html", notebook_display=true)
+```
+
 - [Get started](https://pydeck.gl/installation.html)
 - [Examples](https://pydeck.gl/)
 

--- a/bindings/pydeck/pydeck/bindings/json_tools.py
+++ b/bindings/pydeck/pydeck/bindings/json_tools.py
@@ -3,6 +3,7 @@ Support serializing objects into JSON
 """
 import json
 import re
+import numpy as np
 
 # Attributes to ignore during JSON serialization
 IGNORE_KEYS = [
@@ -91,11 +92,11 @@ def all_numpy_to_list(obj):
         for k, v in obj.items():
             obj[k] = all_numpy_to_list(v)
 
-    if is_array(obj):
+    if  isinstance(obj, (list,np.ndarray)):
         obj = list(obj)
 
         for i, item in enumerate(obj):
-            if is_array(item) or isinstance(item, dict):
+            if isinstance(item, (list,np.ndarray,dict)):
                 obj[i] = all_numpy_to_list(item)
 
     return obj

--- a/bindings/pydeck/pyproject.toml
+++ b/bindings/pydeck/pyproject.toml
@@ -1,11 +1,6 @@
 [project]
 name = "pydeck"
-version = "0.3.0"
-
-requires = [
-    "setuptools",
-    "wheel",
-]
+version = "0.5.0b1"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
changes:
binding/pydeck/json_tools.py :
 - `is_array` not exist, so changed to `isinstance(obj, (list,np.ndarray))`
 - julia number array is converted to numpy.ndarray

pyproject.toml : `requires ` no need

README.md updated for `julia`
